### PR TITLE
Change LocalstackContainer health uri default to _localstack/health

### DIFF
--- a/src/main/java/io/ebean/test/containers/Localstack2Container.java
+++ b/src/main/java/io/ebean/test/containers/Localstack2Container.java
@@ -11,9 +11,9 @@ import java.util.Properties;
  *
  * <pre>{@code
  *
- *     Localstack2Container container = Localstack2Container.builder("0.14")
+ *     Localstack2Container container = Localstack2Container.builder("4.0.3")
  *       // .port(4566)
- *       // .image("localstack/localstack:0.14")
+ *       // .image("localstack/localstack:4.0.3")
  *       .build();
  *
  *     container.start();
@@ -46,10 +46,11 @@ public class Localstack2Container extends BaseContainer<Localstack2Container> {
 
     private String services = "dynamodb";
     private String awsRegion = "ap-southeast-2";
+    private String healthUri = "_localstack/health";
     private String startWeb;
 
     /**
-     * Create with a version of localstack/localstack (example, 0.14)
+     * Create with a version of localstack/localstack (example, 4.0.3)
      */
     private Builder(String version) {
       super("localstack", 4566, 4566, version);
@@ -62,6 +63,7 @@ public class Localstack2Container extends BaseContainer<Localstack2Container> {
       services = prop(properties, "services", services);
       awsRegion = prop(properties, "awsRegion", awsRegion);
       startWeb = prop(properties, "startWeb", startWeb);
+      healthUri = prop(properties, "healthUri", healthUri);
     }
 
     /**
@@ -91,6 +93,14 @@ public class Localstack2Container extends BaseContainer<Localstack2Container> {
     }
 
     /**
+     * Set the healthUri option - defaults to _localstack/health.
+     */
+    public Builder healthUri(String healthUri) {
+      this.healthUri = healthUri;
+      return self();
+    }
+
+    /**
      * Build and return the LocalstackContainer to then start().
      */
     public Localstack2Container build() {
@@ -107,6 +117,7 @@ public class Localstack2Container extends BaseContainer<Localstack2Container> {
   private final String services;
   private final String awsRegion;
   private final String startWeb;
+  private final String healthUri;
 
   /**
    * Create the container using the given config.
@@ -116,11 +127,12 @@ public class Localstack2Container extends BaseContainer<Localstack2Container> {
     this.services = builder.services;
     this.awsRegion = builder.awsRegion;
     this.startWeb = builder.startWeb;
+    this.healthUri = builder.healthUri;
     this.serviceNames = TrimSplit.split(services);
   }
 
   private String healthUrl() {
-    return String.format("http://%s:%s/health", config.getHost(), config.getPort());
+    return String.format("http://%s:%s/%s", config.getHost(), config.getPort(), healthUri);
   }
 
   /**

--- a/src/main/java/io/ebean/test/containers/LocalstackContainer.java
+++ b/src/main/java/io/ebean/test/containers/LocalstackContainer.java
@@ -16,9 +16,9 @@ import java.util.Properties;
  *
  * <pre>{@code
  *
- *     LocalstackContainer container = LocalstackContainer.builder("0.14")
+ *     LocalstackContainer container = LocalstackContainer.builder("4.0.3")
  *       // .port(4566)
- *       // .image("localstack/localstack:0.14")
+ *       // .image("localstack/localstack:4.0.3")
  *       .build();
  *
  *     container.start();
@@ -58,10 +58,11 @@ public class LocalstackContainer extends BaseContainer<LocalstackContainer> {
 
     private String services = "dynamodb";
     private String awsRegion = "ap-southeast-2";
+    private String healthUri = "_localstack/health";
     private String startWeb;// = "0";
 
     /**
-     * Create with a version of localstack/localstack (example, 0.14)
+     * Create with a version of localstack/localstack (example, 4.0.3)
      */
     private Builder(String version) {
       super("localstack", 4566, 4566, version);
@@ -74,6 +75,7 @@ public class LocalstackContainer extends BaseContainer<LocalstackContainer> {
       services = prop(properties, "services", services);
       awsRegion = prop(properties, "awsRegion", awsRegion);
       startWeb = prop(properties, "startWeb", startWeb);
+      healthUri = prop(properties, "healthUri", healthUri);
     }
 
     /**
@@ -103,6 +105,14 @@ public class LocalstackContainer extends BaseContainer<LocalstackContainer> {
     }
 
     /**
+     * Set the healthUri option - defaults to _localstack/health.
+     */
+    public Builder healthUri(String healthUri) {
+      this.healthUri = healthUri;
+      return self();
+    }
+
+    /**
      * Build and return the LocalstackContainer to then start().
      */
     public LocalstackContainer build() {
@@ -119,6 +129,7 @@ public class LocalstackContainer extends BaseContainer<LocalstackContainer> {
   private final String services;
   private final String awsRegion;
   private final String startWeb;
+  private final String healthUri;
 
   /**
    * Create the container using the given config.
@@ -128,11 +139,12 @@ public class LocalstackContainer extends BaseContainer<LocalstackContainer> {
     this.services = builder.services;
     this.awsRegion = builder.awsRegion;
     this.startWeb = builder.startWeb;
+    this.healthUri = builder.healthUri;
     this.serviceNames = TrimSplit.split(services);
   }
 
   private String healthUrl() {
-    return String.format("http://%s:%s/health", config.getHost(), config.getPort());
+    return String.format("http://%s:%s/%s", config.getHost(), config.getPort(), healthUri);
   }
 
   /**

--- a/src/main/java/io/ebean/test/containers/LocalstackSdkV2.java
+++ b/src/main/java/io/ebean/test/containers/LocalstackSdkV2.java
@@ -70,7 +70,7 @@ final class LocalstackSdkV2 implements AwsSDKv2 {
 
   @Override
   public Region region() {
-    return Region.of(awsRegion);
+    return awsRegion == null ? null : Region.of(awsRegion);
   }
 
   @Override

--- a/src/test/java/io/ebean/test/containers/LocalstackContainerV2Test.java
+++ b/src/test/java/io/ebean/test/containers/LocalstackContainerV2Test.java
@@ -27,12 +27,12 @@ class LocalstackContainerV2Test {
   @Disabled
   @Test
   void start_viaBuilder() {
-    Localstack2Container container = Localstack2Container.builder("0.14.4")
+    Localstack2Container container = Localstack2Container.builder("4.0.3")
       .awsRegion("ap-southeast-2")
       .services("dynamodb,kinesis,sns,sqs,s3")
       //.port(4567)
       .containerName("ut_localstack_dkss2")
-      .image("localstack/localstack:0.14.4")
+      .image("localstack/localstack:4.0.3")
       .port(4577)
       .build();
 


### PR DESCRIPTION
This update is needed to support version 3.x+ of the localstack image and updates to the AWS SDK