### PR TITLE
MariaDBContainer should use mariadb driver for health check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <version>3.5.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.sap.cloud.db.jdbc</groupId>
       <artifactId>ngdbc</artifactId>
       <version>2.12.9</version>

--- a/src/main/java/io/ebean/test/containers/MariaDBContainer.java
+++ b/src/main/java/io/ebean/test/containers/MariaDBContainer.java
@@ -45,12 +45,12 @@ public class MariaDBContainer extends BaseMySqlContainer<MariaDBContainer> {
 
     @Override
     protected String buildJdbcUrl() {
-      return "jdbc:mysql://" + getHost() + ":" + getPort() + "/" + getDbName();
+      return "jdbc:mariadb://" + getHost() + ":" + getPort() + "/" + getDbName();
     }
 
     @Override
     protected String buildJdbcAdminUrl() {
-      return "jdbc:mysql://" + getHost() + ":" + getPort() + "/mysql";
+      return "jdbc:mariadb://" + getHost() + ":" + getPort() + "/mysql";
     }
 
     @Override


### PR DESCRIPTION
MariaDB uses the MySQL driver for health check.

This is not problematic for health check, because MariaDB and MySQL is widely compatible.
But need to put an additional driver in your test scope and you might get legal/license issues, because of the GPL license of the MySQL driver.

So let's use MariaDB driver fro MariaDB containers and MySQL driver for MySQL containers

