### PR TITLE
MySql MariaDB - Add support for extraDb

### DIFF
--- a/src/test/java/io/ebean/test/containers/BaseMySqlContainerTest.java
+++ b/src/test/java/io/ebean/test/containers/BaseMySqlContainerTest.java
@@ -1,0 +1,36 @@
+package io.ebean.test.containers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BaseMySqlContainerTest {
+
+  @Test
+  void toDatabaseNames() {
+    List<String> names = BaseMySqlContainer.toDatabaseNames("foo");
+    assertThat(names).containsExactly("foo");
+
+    names = BaseMySqlContainer.toDatabaseNames("foo,");
+    assertThat(names).containsExactly("foo");
+    names = BaseMySqlContainer.toDatabaseNames(",foo,");
+    assertThat(names).containsExactly("foo");
+    names = BaseMySqlContainer.toDatabaseNames(",foo");
+    assertThat(names).containsExactly("foo");
+  }
+
+  @Test
+  void toDatabaseNames_multiple() {
+    List<String> names = BaseMySqlContainer.toDatabaseNames(" foo , bar ");
+    assertThat(names).containsExactly("foo", "bar");
+
+    names = BaseMySqlContainer.toDatabaseNames("foo,bar");
+    assertThat(names).containsExactly("foo", "bar");
+    names = BaseMySqlContainer.toDatabaseNames(",foo,bar,");
+    assertThat(names).containsExactly("foo", "bar");
+    names = BaseMySqlContainer.toDatabaseNames("  ,  foo  ,  bar  ,  ");
+    assertThat(names).containsExactly("foo", "bar");
+  }
+}

--- a/src/test/java/io/ebean/test/containers/MariaDBContainerTest.java
+++ b/src/test/java/io/ebean/test/containers/MariaDBContainerTest.java
@@ -34,6 +34,7 @@ class MariaDBContainerTest {
   void start() {
     MariaDBContainer container = MariaDBContainer.builder("latest")
       .containerName("temp_mariadb")
+      .extraDb("foo, bar")
       .port(8306)
       .fastStartMode(true)
       .build();


### PR DESCRIPTION
Support added extra databases for MySql and MariaDB.

Example:

```java
MariaDBContainer container = MariaDBContainer.builder("latest")
      .extraDb("another, other")
      .port(8306)
      .build();
```