### PR TITLE
Fix flaky SqlServer startup issue

### DIFF
--- a/src/main/java/io/ebean/test/containers/SqlServerContainer.java
+++ b/src/main/java/io/ebean/test/containers/SqlServerContainer.java
@@ -172,6 +172,8 @@ public class SqlServerContainer extends BaseJdbcContainer<SqlServerContainer> {
   }
 
   private void dropDatabase(Connection connection, String dbName) {
+    sqlRun(connection, "alter database " + dbName + " set offline with rollback immediate"); // close all connections to DB
+    sqlRun(connection, "alter database " + dbName + " set online");
     sqlRun(connection, "drop database " + dbName);
   }
 

--- a/src/test/java/io/ebean/test/containers/SqlServerContainerTest.java
+++ b/src/test/java/io/ebean/test/containers/SqlServerContainerTest.java
@@ -28,6 +28,27 @@ class SqlServerContainerTest {
     container.stopRemove();
   }
 
+  /**
+   * startWithDropCreate does not work, when the container is running and there is a connection open.
+   */
+  @Disabled
+  @Test
+  void start_dropCreate_withLeakingConnection() throws Exception {
+    SqlServerContainer container = SqlServerContainer.builder(SQLSERVER_VER)
+      .containerName("temp_sqlserver")
+      .port(2433)
+      .collation("Latin1_General_100_BIN2")
+      .build();
+    container.startWithDropCreate();
+    try (Connection conn = DriverManager.getConnection(container.jdbcUrl(), container.dbConfig.getUsername(), container.dbConfig.getPassword())) {
+      // drop during open connection
+      container.startWithDropCreate();
+    } finally {
+      container.stopRemove();
+
+    }
+  }
+
   @Disabled
   @Test
   void start_when_defaultCollation() {


### PR DESCRIPTION
I think we found the reason, why SqlServer is often flaky.

It is a timming issue, when the db is accessed while collation conversion is still in progress and heavily depends on the type of the container, the machine and the current cpu load to hit the right spot.

This should fix https://github.com/ebean-orm/ebean/issues/2917