### PR TITLE
Change baseImage to icr.io/db2_community/db2 and made dockerSu public

### DIFF
--- a/src/main/java/io/ebean/test/containers/Db2Container.java
+++ b/src/main/java/io/ebean/test/containers/Db2Container.java
@@ -44,7 +44,7 @@ public class Db2Container extends BaseJdbcContainer<Db2Container> {
 
     private Builder(String version) {
       super("db2", 50000, 50000, version);
-      this.image = "ibmcom/db2:" + version;
+      this.image = "icr.io/db2_community/db2:" + version;
       this.tmpfs = "/database:rw";
     }
 
@@ -184,7 +184,7 @@ public class Db2Container extends BaseJdbcContainer<Db2Container> {
   /**
    * Runs the given (linux) command inside the container as given user.
    */
-  protected List<String> dockerSu(String user, String cmd) {
+  public List<String> dockerSu(String user, String cmd) {
     List<String> args = new ArrayList<>();
     args.add(config.docker());
     args.add("exec");
@@ -203,7 +203,7 @@ public class Db2Container extends BaseJdbcContainer<Db2Container> {
   /**
    * Executes the (linux) command as DB-admin user.
    */
-  protected List<String> dockerSu(String cmd) {
+  public List<String> dockerSu(String cmd) {
     return dockerSu(dbConfig.getAdminUsername(), cmd);
   }
 

--- a/src/test/java/io/ebean/test/containers/Db2ContainerTest.java
+++ b/src/test/java/io/ebean/test/containers/Db2ContainerTest.java
@@ -14,7 +14,7 @@ class Db2ContainerTest {
   @Disabled
   @Test
   void start() {
-    Db2Container container = Db2Container.builder("11.5.4.0")
+    Db2Container container = Db2Container.builder("11.5.8.0")
       .containerName("temp_db2")
       .port(50050)
       .fastStartMode(true)
@@ -25,13 +25,14 @@ class Db2ContainerTest {
     container.startWithDropCreate();
 
     container.stopRemove();
+    container.dockerSu()
   }
 
   @Disabled
   @Test
   void viaContainerFactory() {
     Properties properties = new Properties();
-    properties.setProperty("db2.version", "11.5.4.0");
+    properties.setProperty("db2.version", "11.5.8.0");
     properties.setProperty("db2.containerName", "temp_db2");
     properties.setProperty("db2.port", "50050");
 


### PR DESCRIPTION
Hello @rbygrave, this should be a relative low hanging fruit.

It changes the base-image to icr.io/db2_community/db2 because the other is no longer maintained (see https://hub.docker.com/r/ibmcom/db2)
But this might be also a **breaking change** as there are no versions < 11.5.8.0 on this registry.
So users must upgrade at least to this version (or use `image=ibmcom/db2:11.5.4.0`)

OTOH definitions like
```
ebean.test.db2.version=11.5.9.0
ebean.test.db2.image=icr.io/db2_community/db2
```
are wrong. `image` overwrites the previous set version and the latest container (in this cas 12.1) will be launched.
A working definition could be:
```
ebean.test.db2.version=willBeIgnored
ebean.test.db2.image=icr.io/db2_community/db2:11.5.9.0
```
or re-append the version to the image. But for now, I would like to keep it simple and just change the container registry for now

The next change: I would like to make `dockerSu` public. I need this in some tests to fine tune the docker container. E.g. set up trusted context: https://github.com/FOCONIS/ebean-datasource/blob/mariadb-stealing/ebean-datasource/src/test/java/io/ebean/datasource/test/Db2TrustedContextTest.java#L117

