### PR TITLE
For PostgisContainer add useLW(true) support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,13 @@
     </dependency>
 
     <dependency>
+      <groupId>net.postgis</groupId>
+      <artifactId>postgis-jdbc</artifactId>
+      <version>2023.1.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>ru.yandex.clickhouse</groupId>
       <artifactId>clickhouse-jdbc</artifactId>
       <version>0.3.2</version>

--- a/src/main/java/io/ebean/test/containers/PostgisContainer.java
+++ b/src/main/java/io/ebean/test/containers/PostgisContainer.java
@@ -35,6 +35,8 @@ public class PostgisContainer extends BasePostgresContainer<PostgisContainer> {
    */
   public static class Builder extends BaseDbBuilder<PostgisContainer, Builder> {
 
+    private boolean useLW;
+
     private Builder(String version) {
       super("postgis", 6432, 5432, version);
       this.image = "ghcr.io/baosystems/postgis:" + version;
@@ -44,19 +46,32 @@ public class PostgisContainer extends BasePostgresContainer<PostgisContainer> {
       this.extraDbExtensions = extensions;
     }
 
+    private String prefix() {
+      return useLW ? "jdbc:postgresql_lwgis://" : "jdbc:postgresql://";
+    }
+
     @Override
     protected String buildJdbcUrl() {
-      return "jdbc:postgresql://" + host + ":" + port + "/" + dbName;
+      return prefix() + host + ":" + port + "/" + dbName;
     }
 
     @Override
     protected String buildJdbcAdminUrl() {
-      return "jdbc:postgresql://" + host + ":" + port + "/postgres";
+      return prefix() + host + ":" + port + "/postgres";
     }
 
     @Override
     protected String buildExtraJdbcUrl() {
-      return "jdbc:postgresql://" + host + ":" + port + "/" + extraDb;
+      return prefix() + host + ":" + port + "/" + extraDb;
+    }
+
+    /**
+     * Set to use HexWKB and DriverWrapperLW. The JDBC URL will prefix with
+     * <code>jdbc:postgresql_lwgis://</code> instead of <code>jdbc:postgresql://</code>.
+     */
+    Builder useLW(boolean useLW) {
+      this.useLW = useLW;
+      return this;
     }
 
     @Override

--- a/src/test/java/io/ebean/test/containers/PostgisContainerTest.java
+++ b/src/test/java/io/ebean/test/containers/PostgisContainerTest.java
@@ -16,6 +16,7 @@ class PostgisContainerTest {
   void extraDb() throws java.sql.SQLException {
     PostgisContainer container = PostgisContainer.builder("15")
       .port(0)
+      .useLW(true)
       .extraDb("myextra")
       .build();
 
@@ -27,6 +28,7 @@ class PostgisContainerTest {
 
     String jdbcUrl = container.config().jdbcUrl();
     assertThat(jdbcUrl).contains(":" + containerConfig.port());
+    assertThat(jdbcUrl).startsWith("jdbc:postgresql_lwgis://");
     runSomeSql(container);
 
     DataSourcePool dataSource = container.ebean().dataSourceBuilder().build();


### PR DESCRIPTION
This allows the connection jdbc url to have the prefix of `jdbc:postgresql_lwgis` rather than the usual `jdbc:postgresql`

```java
    PostgisContainer container = PostgisContainer.builder("15")
      .useLW(true)
      .build();
```