### PR TITLE
Support programmatic configuration of a 2nd extra database with Postgres

### DIFF
--- a/src/main/java/io/ebean/test/containers/BaseBuilder.java
+++ b/src/main/java/io/ebean/test/containers/BaseBuilder.java
@@ -335,7 +335,7 @@ abstract class BaseBuilder<C, SELF extends BaseBuilder<C, SELF>> implements Cont
   /**
    * Override to build jdbc url for extraDb.
    */
-  protected String buildExtraJdbcUrl() {
+  protected String buildExtraJdbcUrl(String dbName) {
     throw new IllegalStateException("Not valid for this type");
   }
 
@@ -396,8 +396,8 @@ abstract class BaseBuilder<C, SELF extends BaseBuilder<C, SELF>> implements Cont
     }
 
     @Override
-    public String jdbcExtraUrl() {
-      return buildExtraJdbcUrl();
+    public String jdbcUrl(String dbName) {
+      return buildExtraJdbcUrl(dbName);
     }
 
     @Override

--- a/src/main/java/io/ebean/test/containers/BaseDbBuilder.java
+++ b/src/main/java/io/ebean/test/containers/BaseDbBuilder.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.function.Consumer;
 
 /**
  * Configuration for an DBMS like Postgres, MySql, Oracle, SQLServer
@@ -25,15 +26,8 @@ abstract class BaseDbBuilder<C, SELF extends BaseDbBuilder<C, SELF>> extends Bas
    */
   String adminPassword = "admin";
 
-  /**
-   * An additional database.
-   */
-  String extraDb;
-  private String extraDbUser;
-  private String extraDbPassword = "test";
-  String extraDbExtensions;
-  private String extraDbInitSqlFile;
-  private String extraDbSeedSqlFile;
+  final ExtraAttributes extra = new ExtraAttributes();
+  final ExtraAttributes extra2 = new ExtraAttributes();
 
   /**
    * Database name to use.
@@ -123,13 +117,8 @@ abstract class BaseDbBuilder<C, SELF extends BaseDbBuilder<C, SELF>> extends Bas
     adminPassword = prop(properties, "adminPassword", adminPassword);
     initSqlFile = prop(properties, "initSqlFile", initSqlFile);
     seedSqlFile = prop(properties, "seedSqlFile", seedSqlFile);
-
-    extraDb = prop(properties, "extraDb.dbName", prop(properties, "extraDb", extraDb));
-    extraDbUser = prop(properties, "extraDb.username", extraDbUser);
-    extraDbPassword = prop(properties, "extraDb.password", extraDbPassword);
-    extraDbExtensions = prop(properties, "extraDb.extensions", extraDbExtensions);
-    extraDbInitSqlFile = prop(properties, "extraDb.initSqlFile", extraDbInitSqlFile);
-    extraDbSeedSqlFile = prop(properties, "extraDb.seedSqlFile", extraDbSeedSqlFile);
+    extra.load(platform, "extraDb", properties);
+    extra2.load(platform, "extra2Db", properties);
     return self();
   }
 
@@ -270,7 +259,7 @@ abstract class BaseDbBuilder<C, SELF extends BaseDbBuilder<C, SELF>> extends Bas
    */
   @Override
   public SELF extraDb(String extraDb) {
-    this.extraDb = extraDb;
+    this.extra.dbName = extraDb;
     return self();
   }
 
@@ -282,7 +271,7 @@ abstract class BaseDbBuilder<C, SELF extends BaseDbBuilder<C, SELF>> extends Bas
    */
   @Override
   public SELF extraDbUser(String extraDbUser) {
-    this.extraDbUser = extraDbUser;
+    this.extra.username = extraDbUser;
     return self();
   }
 
@@ -294,13 +283,13 @@ abstract class BaseDbBuilder<C, SELF extends BaseDbBuilder<C, SELF>> extends Bas
    */
   @Override
   public SELF extraDbPassword(String extraDbPassword) {
-    this.extraDbPassword = extraDbPassword;
+    this.extra.password = extraDbPassword;
     return self();
   }
 
   @Override
   public SELF extraDbExtensions(String extraDbExtensions) {
-    this.extraDbExtensions = extraDbExtensions;
+    this.extra.extensions = extraDbExtensions;
     return self();
   }
 
@@ -309,7 +298,7 @@ abstract class BaseDbBuilder<C, SELF extends BaseDbBuilder<C, SELF>> extends Bas
    */
   @Override
   public SELF extraDbInitSqlFile(String extraDbInitSqlFile) {
-    this.extraDbInitSqlFile = extraDbInitSqlFile;
+    this.extra.initSqlFile = extraDbInitSqlFile;
     return self();
   }
 
@@ -318,7 +307,19 @@ abstract class BaseDbBuilder<C, SELF extends BaseDbBuilder<C, SELF>> extends Bas
    */
   @Override
   public SELF extraDbSeedSqlFile(String extraDbSeedSqlFile) {
-    this.extraDbSeedSqlFile = extraDbSeedSqlFile;
+    this.extra.seedSqlFile = extraDbSeedSqlFile;
+    return self();
+  }
+
+  @Override
+  public SELF extra(Consumer<ExtraBuilder> extraBuilder) {
+    extraBuilder.accept(extra);
+    return self();
+  }
+
+  @Override
+  public SELF extra2(Consumer<ExtraBuilder> extraBuilder) {
+    extraBuilder.accept(extra2);
     return self();
   }
 
@@ -469,43 +470,13 @@ abstract class BaseDbBuilder<C, SELF extends BaseDbBuilder<C, SELF>> extends Bas
     }
 
     @Override
-    public String getExtraDb() {
-      return extraDb;
+    public ExtraAttributes extra() {
+      return extra;
     }
 
     @Override
-    public String getExtraDbUser() {
-      return extraDbUser;
-    }
-
-    @Override
-    public String getExtraDbUserWithDefault() {
-      return extraDbUser != null ? extraDbUser : extraDb;
-    }
-
-    @Override
-    public String getExtraDbPassword() {
-      return extraDbPassword;
-    }
-
-    @Override
-    public String getExtraDbPasswordWithDefault() {
-      return extraDbPassword != null ? extraDbPassword : password;
-    }
-
-    @Override
-    public String getExtraDbExtensions() {
-      return extraDbExtensions;
-    }
-
-    @Override
-    public String getExtraDbInitSqlFile() {
-      return extraDbInitSqlFile;
-    }
-
-    @Override
-    public String getExtraDbSeedSqlFile() {
-      return extraDbSeedSqlFile;
+    public ExtraAttributes extra2() {
+      return extra2;
     }
 
     @Override

--- a/src/main/java/io/ebean/test/containers/BaseMySqlContainer.java
+++ b/src/main/java/io/ebean/test/containers/BaseMySqlContainer.java
@@ -27,7 +27,7 @@ abstract class BaseMySqlContainer<C extends BaseMySqlContainer<C>> extends BaseJ
       if (withDrop) {
         dropUserIfExists(connection, dbConfig.getUsername());
         dropDatabaseIfExists(connection, dbConfig.getDbName());
-        for (String extraDb : toDatabaseNames(dbConfig.getExtraDb())) {
+        for (String extraDb : toDatabaseNames(dbConfig.extra().dbName())) {
           dropDatabaseIfExists(connection, extraDb);
         }
       }
@@ -55,7 +55,7 @@ abstract class BaseMySqlContainer<C extends BaseMySqlContainer<C>> extends BaseJ
     if (!userExists(connection, dbConfig.getUsername())) {
       sqlRun(connection, "create user '" + dbConfig.getUsername() + "'@'%' identified by '" + dbConfig.getPassword() + "'");
       sqlRun(connection, "grant all on " + dbConfig.getDbName() + ".* to '" + dbConfig.getUsername() + "'@'%'");
-      for (String extraDb : toDatabaseNames(dbConfig.getExtraDb())) {
+      for (String extraDb : toDatabaseNames(dbConfig.extra().dbName())) {
         sqlRun(connection, "grant all on " + extraDb + ".* to '" + dbConfig.getUsername() + "'@'%'");
       }
     }
@@ -72,7 +72,7 @@ abstract class BaseMySqlContainer<C extends BaseMySqlContainer<C>> extends BaseJ
   }
 
   private void createExtraDatabases(Connection connection) {
-    for (String extraDb : toDatabaseNames(dbConfig.getExtraDb())) {
+    for (String extraDb : toDatabaseNames(dbConfig.extra().dbName())) {
       createDatabase(connection, extraDb);
     }
   }

--- a/src/main/java/io/ebean/test/containers/ContainerBuilderDb.java
+++ b/src/main/java/io/ebean/test/containers/ContainerBuilderDb.java
@@ -1,5 +1,7 @@
 package io.ebean.test.containers;
 
+import java.util.function.Consumer;
+
 /**
  * Builder for DB containers.
  */
@@ -94,6 +96,16 @@ public interface ContainerBuilderDb<C, SELF extends ContainerBuilderDb<C, SELF>>
    * Set extra database seed sql file to execute.
    */
   SELF extraDbSeedSqlFile(String extraDbSeedSqlFile);
+
+  /**
+   * Create an additional extra database with the given attributes.
+   */
+  SELF extra(Consumer<ExtraBuilder> extraBuilder);
+
+  /**
+   * Create a second additional extra database with the given attributes.
+   */
+  SELF extra2(Consumer<ExtraBuilder> extraBuilder);
 
   /**
    * Set to true to use in-memory database if supported.

--- a/src/main/java/io/ebean/test/containers/ContainerConfig.java
+++ b/src/main/java/io/ebean/test/containers/ContainerConfig.java
@@ -39,7 +39,7 @@ public interface ContainerConfig {
   /**
    * Return a DB connection url or null for the extra database.
    */
-  String jdbcExtraUrl();
+  String jdbcUrl(String dbName);
 
   /**
    * Return a DB connection url for the admin database user.

--- a/src/main/java/io/ebean/test/containers/EbeanAdapter.java
+++ b/src/main/java/io/ebean/test/containers/EbeanAdapter.java
@@ -1,48 +1,69 @@
 package io.ebean.test.containers;
 
+import io.ebean.DatabaseBuilder;
+import io.ebean.datasource.DataSourceBuilder;
+
 final class EbeanAdapter implements EbeanSDK {
 
-  private final InternalConfigDb dbConfig;
+    private final InternalConfigDb dbConfig;
 
-  EbeanAdapter(InternalConfigDb dbConfig) {
-    this.dbConfig = dbConfig;
-  }
+    EbeanAdapter(InternalConfigDb dbConfig) {
+        this.dbConfig = dbConfig;
+    }
 
-  @Override
-  public io.ebean.DatabaseBuilder builder() {
-    return io.ebean.Database.builder()
-      .dataSourceBuilder(dataSourceBuilder())
-      .name(dbConfig.getDbName())
-      .register(false)
-      .ddlGenerate(true)
-      .ddlRun(true);
-  }
+    @Override
+    public io.ebean.DatabaseBuilder builder() {
+        return io.ebean.Database.builder()
+                .dataSourceBuilder(dataSourceBuilder())
+                .name(dbConfig.getDbName())
+                .register(false)
+                .ddlGenerate(true)
+                .ddlRun(true);
+    }
 
+    @Override
+    public io.ebean.datasource.DataSourceBuilder dataSourceBuilder() {
+        return io.ebean.datasource.DataSourceBuilder.create()
+                .url(dbConfig.jdbcUrl())
+                .username(dbConfig.getUsername())
+                .password(dbConfig.getPassword());
+    }
 
-  @Override
-  public io.ebean.datasource.DataSourceBuilder dataSourceBuilder() {
-    return io.ebean.datasource.DataSourceBuilder.create()
-      .url(dbConfig.jdbcUrl())
-      .username(dbConfig.getUsername())
-      .password(dbConfig.getPassword());
-  }
+    private DataSourceBuilder dataSourceBuilder(ExtraAttributes extra) {
+        final String username = extra.userWithDefaults(dbConfig.getUsername());
+        final String password = extra.passwordWithDefault(dbConfig.getPassword());
+        return DataSourceBuilder.create()
+                .url(dbConfig.jdbcUrl(extra.dbName()))
+                .username(username)
+                .password(password);
+    }
 
+    @Override
+    public io.ebean.datasource.DataSourceBuilder extraDataSourceBuilder() {
+        return dataSourceBuilder(dbConfig.extra());
+    }
 
-  @Override
-  public io.ebean.datasource.DataSourceBuilder extraDataSourceBuilder() {
-    return io.ebean.datasource.DataSourceBuilder.create()
-      .url(dbConfig.jdbcExtraUrl())
-      .username(dbConfig.getExtraDbUserWithDefault())
-      .password(dbConfig.getExtraDbPasswordWithDefault());
-  }
+    @Override
+    public io.ebean.datasource.DataSourceBuilder extra2DataSourceBuilder() {
+        return dataSourceBuilder(dbConfig.extra2());
+    }
 
-  @Override
-  public io.ebean.DatabaseBuilder extraDatabaseBuilder() {
-    return io.ebean.Database.builder()
-      .dataSourceBuilder(extraDataSourceBuilder())
-      .name(dbConfig.getExtraDb())
-      .defaultDatabase(false)
-      .register(false);
-  }
+    @Override
+    public io.ebean.DatabaseBuilder extraDatabaseBuilder() {
+        return extraBuilder(extraDataSourceBuilder(), dbConfig.extra().dbName());
+    }
+
+    @Override
+    public io.ebean.DatabaseBuilder extra2DatabaseBuilder() {
+        return extraBuilder(extra2DataSourceBuilder(), dbConfig.extra2().dbName());
+    }
+
+    private static DatabaseBuilder extraBuilder(DataSourceBuilder ds, String name) {
+        return io.ebean.Database.builder()
+                .dataSourceBuilder(ds)
+                .name(name)
+                .defaultDatabase(false)
+                .register(false);
+    }
 
 }

--- a/src/main/java/io/ebean/test/containers/EbeanSDK.java
+++ b/src/main/java/io/ebean/test/containers/EbeanSDK.java
@@ -16,28 +16,38 @@ package io.ebean.test.containers;
  */
 public interface EbeanSDK {
 
-  /**
-   * Return an ebean Database builder for the underlying database (url, username, password).
-   * <p>
-   * The name of the ebean database will be dbName set for the container.
-   * <p>
-   * This builder will have ddlGenerate set to true and ddlRun set to true. Alternatively,
-   * set runMigrations(true) to run database migrations on startup.
-   */
-  io.ebean.DatabaseBuilder builder();
+    /**
+     * Return an ebean Database builder for the underlying database (url, username, password).
+     * <p>
+     * The name of the ebean database will be dbName set for the container.
+     * <p>
+     * This builder will have ddlGenerate set to true and ddlRun set to true. Alternatively,
+     * set runMigrations(true) to run database migrations on startup.
+     */
+    io.ebean.DatabaseBuilder builder();
 
-  /**
-   * Return a java.sql.DataSource builder for the underlying database (url, username, password).
-   */
-  io.ebean.datasource.DataSourceBuilder dataSourceBuilder();
+    /**
+     * Return a DataSource builder for the underlying database (url, username, password).
+     */
+    io.ebean.datasource.DataSourceBuilder dataSourceBuilder();
 
-  /**
-   * Return a java.sql.DataSource builder for the underlying database (url, username, password).
-   */
-  io.ebean.datasource.DataSourceBuilder extraDataSourceBuilder();
+    /**
+     * Return a DataSource builder for the extra database (url, username, password).
+     */
+    io.ebean.datasource.DataSourceBuilder extraDataSourceBuilder();
 
-  /**
-   * Return an ebean Database builder for the EXTRA database (extraUrl, extraDbUser, extraDbPassword).
-   */
-  io.ebean.DatabaseBuilder extraDatabaseBuilder();
+    /**
+     * Return a DataSource builder for the second extra database (url, username, password).
+     */
+    io.ebean.datasource.DataSourceBuilder extra2DataSourceBuilder();
+
+    /**
+     * Return an ebean Database builder for the EXTRA database.
+     */
+    io.ebean.DatabaseBuilder extraDatabaseBuilder();
+
+    /**
+     * Return an ebean Database builder for the second EXTRA2 database.
+     */
+    io.ebean.DatabaseBuilder extra2DatabaseBuilder();
 }

--- a/src/main/java/io/ebean/test/containers/ExtraAttributes.java
+++ b/src/main/java/io/ebean/test/containers/ExtraAttributes.java
@@ -1,0 +1,92 @@
+package io.ebean.test.containers;
+
+import java.util.Properties;
+
+final class ExtraAttributes implements ExtraBuilder {
+
+  String dbName;
+  String extensions;
+  String username;
+  String password = "test";
+  String initSqlFile;
+  String seedSqlFile;
+
+  String dbName() {
+    return dbName;
+  }
+
+  String userWithDefaults(String username) {
+    String un = userWithDefault();
+    return un != null && !un.equals(username) ? un : null;
+  }
+
+  private String userWithDefault() {
+    return username != null ? username : dbName;
+  }
+
+  String passwordWithDefault(String password) {
+    return this.password != null ? this.password : password;
+  }
+
+  String extensions() {
+    return extensions;
+  }
+
+  String initSqlFile() {
+    return initSqlFile;
+  }
+
+  String seedSqlFile() {
+    return seedSqlFile;
+  }
+
+  void load(String platform, String prefix, Properties properties) {
+    dbName = prop(platform, properties, prefix + ".dbName", prop(platform, properties, prefix, dbName));
+    username = prop(platform, properties, prefix + ".username", username);
+    password = prop(platform, properties, prefix + ".password", password);
+    extensions = prop(platform, properties, prefix + ".extensions", extensions);
+    initSqlFile = prop(platform, properties, prefix + ".initSqlFile", initSqlFile);
+    seedSqlFile = prop(platform, properties, prefix + ".seedSqlFile", seedSqlFile);
+  }
+
+  private String prop(String platform, Properties properties, String key, String defaultValue) {
+    String val = properties.getProperty("ebean.test." + platform + "." + key, defaultValue);
+    return properties.getProperty(platform + "." + key, val);
+  }
+
+  @Override
+  public ExtraBuilder dbName(String dbName) {
+    this.dbName = dbName;
+    return this;
+  }
+
+  @Override
+  public ExtraBuilder extensions(String extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
+  @Override
+  public ExtraBuilder username(String username) {
+    this.username = username;
+    return this;
+  }
+
+  @Override
+  public ExtraBuilder password(String password) {
+    this.password = password;
+    return this;
+  }
+
+  @Override
+  public ExtraBuilder initSqlFile(String initSqlFile) {
+    this.initSqlFile = initSqlFile;
+    return this;
+  }
+
+  @Override
+  public ExtraBuilder seedSqlFile(String seedSqlFile) {
+    this.seedSqlFile = seedSqlFile;
+    return this;
+  }
+}

--- a/src/main/java/io/ebean/test/containers/ExtraBuilder.java
+++ b/src/main/java/io/ebean/test/containers/ExtraBuilder.java
@@ -1,0 +1,37 @@
+package io.ebean.test.containers;
+
+/**
+ * Builder for attributes on an extra database.
+ */
+public interface ExtraBuilder {
+
+  /**
+   * Set the database name.
+   */
+  ExtraBuilder dbName(String dbName);
+
+  /**
+   * Set the extensions.
+   */
+  ExtraBuilder extensions(String extensions);
+
+  /**
+   * Set the username.
+   */
+  ExtraBuilder username(String username);
+
+  /**
+   * Set the password.
+   */
+  ExtraBuilder password(String password);
+
+  /**
+   * Set the initSqlFile.
+   */
+  ExtraBuilder initSqlFile(String initSqlFile);
+
+  /**
+   * Set the seedSqlFile.
+   */
+  ExtraBuilder seedSqlFile(String seedSqlFile);
+}

--- a/src/main/java/io/ebean/test/containers/InternalConfigDb.java
+++ b/src/main/java/io/ebean/test/containers/InternalConfigDb.java
@@ -26,21 +26,9 @@ interface InternalConfigDb extends InternalConfig {
 
   String getSeedSqlFile();
 
-  String getExtraDb();
+  ExtraAttributes extra();
 
-  String getExtraDbUser();
-
-  String getExtraDbUserWithDefault();
-
-  String getExtraDbPassword();
-
-  String getExtraDbPasswordWithDefault();
-
-  String getExtraDbExtensions();
-
-  String getExtraDbInitSqlFile();
-
-  String getExtraDbSeedSqlFile();
+  ExtraAttributes extra2();
 
   boolean isFastStartMode();
 

--- a/src/main/java/io/ebean/test/containers/PostgisContainer.java
+++ b/src/main/java/io/ebean/test/containers/PostgisContainer.java
@@ -43,7 +43,8 @@ public class PostgisContainer extends BasePostgresContainer<PostgisContainer> {
       this.adminUsername = "postgres";
       this.tmpfs = "/var/lib/postgresql/data:rw";
       this.extensions = "hstore,pgcrypto,postgis";
-      this.extraDbExtensions = extensions;
+      this.extra.extensions = extensions;
+      this.extra2.extensions = extensions;
     }
 
     private String prefix() {
@@ -61,8 +62,8 @@ public class PostgisContainer extends BasePostgresContainer<PostgisContainer> {
     }
 
     @Override
-    protected String buildExtraJdbcUrl() {
-      return prefix() + host + ":" + port + "/" + extraDb;
+    protected String buildExtraJdbcUrl(String dbName) {
+      return prefix() + host + ":" + port + "/" + dbName;
     }
 
     /**

--- a/src/main/java/io/ebean/test/containers/PostgresContainer.java
+++ b/src/main/java/io/ebean/test/containers/PostgresContainer.java
@@ -69,8 +69,8 @@ public class PostgresContainer extends BasePostgresContainer<PostgresContainer> 
     }
 
     @Override
-    protected String buildExtraJdbcUrl() {
-      return "jdbc:postgresql://" + host + ":" + port + "/" + extraDb;
+    protected String buildExtraJdbcUrl(String dbName) {
+      return "jdbc:postgresql://" + host + ":" + port + "/" + dbName;
     }
 
     @Override

--- a/src/test/java/io/ebean/test/containers/PostgresConfigTest.java
+++ b/src/test/java/io/ebean/test/containers/PostgresConfigTest.java
@@ -89,9 +89,9 @@ class PostgresConfigTest {
 
     assertEquals(config.getInitSqlFile(), "init.sql");
     assertEquals(config.getSeedSqlFile(), "seed.sql");
-    assertEquals(config.getExtraDbInitSqlFile(), "extra_init.sql");
-    assertEquals(config.getExtraDbSeedSqlFile(), "extra_seed.sql");
-    assertEquals(config.getExtraDbExtensions(), "hstore,pgcrypto");
+    assertEquals(config.extra().initSqlFile(), "extra_init.sql");
+    assertEquals(config.extra().seedSqlFile(), "extra_seed.sql");
+    assertEquals(config.extra().extensions(), "hstore,pgcrypto");
 
     assertEquals(config.jdbcAdminUrl(), "jdbc:postgresql://172.17.0.1:9823/postgres");
     assertEquals(config.jdbcUrl(), "jdbc:postgresql://172.17.0.1:9823/baz");

--- a/src/test/java/io/ebean/test/containers/PostgresContainerTest.java
+++ b/src/test/java/io/ebean/test/containers/PostgresContainerTest.java
@@ -28,6 +28,10 @@ class PostgresContainerTest {
       .extraDbUser("extra1")
       .extraDbPassword("extraPwd")
       .extraDbExtensions("pgcrypto")
+      .extraDbInitSqlFile("init-extra-database.sql")
+      .extra2(e -> e.dbName("my_extra2")
+        .username("my_extra2user")
+        .initSqlFile("init-extra2-database.sql"))
       .build();
 
     container.startMaybe();
@@ -39,6 +43,12 @@ class PostgresContainerTest {
     String jdbcUrl = container.config().jdbcUrl();
     assertThat(jdbcUrl).contains(":" + containerConfig.port());
     runSomeSql(container);
+
+    Database ebeanExtra = container.ebean().extraDatabaseBuilder().build();
+    ebeanExtra.sqlUpdate("insert into foo_extra (acol) values (44)").execute();
+
+    Database ebeanExtra2 = container.ebean().extra2DatabaseBuilder().build();
+    ebeanExtra2.sqlUpdate("insert into bar_extra2 (acol) values (44)").execute();
   }
 
   @Test

--- a/src/test/resources/init-extra2-database.sql
+++ b/src/test/resources/init-extra2-database.sql
@@ -1,0 +1,1 @@
+create table bar_extra2 (acol integer);


### PR DESCRIPTION
So we can programmatically configure the main database and 2 additional extra databases. This is for the case where we simulate an application that has an additional source and destination database as well as the main one for the application.