### PR TITLE
Update for ClickHouse which now requires password

### DIFF
--- a/src/main/java/io/ebean/test/containers/BaseJdbcContainer.java
+++ b/src/main/java/io/ebean/test/containers/BaseJdbcContainer.java
@@ -50,7 +50,7 @@ abstract class BaseJdbcContainer<C extends BaseJdbcContainer<C>> extends DbConta
       return false;
     }
     try (Connection connection = dbConfig.createAdminConnection()) {
-      return true;
+      return connection.isValid(1);
     } catch (Throwable e) {
       // no connectivity
       return false;

--- a/src/main/java/io/ebean/test/containers/ClickHouseContainer.java
+++ b/src/main/java/io/ebean/test/containers/ClickHouseContainer.java
@@ -22,23 +22,25 @@ public class ClickHouseContainer extends BaseJdbcContainer<ClickHouseContainer> 
 
   public static class Builder extends BaseDbBuilder<ClickHouseContainer, Builder> {
 
+    private String jdbcUrlPrefix = "jdbc:clickhouse://";
+
     private Builder(String version) {
       super("clickhouse", 8123, 8123, version);
       this.image = "clickhouse/clickhouse-server:" + version;
       this.username = "default";
-      this.password = "";
+      this.password = "test";
       this.adminUsername = "default";
-      this.adminPassword = "";
+      this.adminPassword = "test";
     }
 
     @Override
     protected String buildJdbcUrl() {
-      return "jdbc:clickhouse://" + getHost() + ":" + getPort() + "/" + getDbName();
+      return jdbcUrlPrefix + getHost() + ":" + getPort() + "/" + getDbName();
     }
 
     @Override
     protected String buildJdbcAdminUrl() {
-      return "jdbc:clickhouse://" + getHost() + ":" + getPort() + "/default";
+      return jdbcUrlPrefix + getHost() + ":" + getPort(); // + "/system";
     }
 
     /**
@@ -47,6 +49,14 @@ public class ClickHouseContainer extends BaseJdbcContainer<ClickHouseContainer> 
     @Override
     public Builder user(String user) {
       return super.user(user);
+    }
+
+    /**
+     * Set the jdbc prefix. Defaults to {@code jdbc:clickhouse://}
+     */
+    public Builder jdbcUrlPrefix(String jdbcUrlPrefix) {
+      this.jdbcUrlPrefix = jdbcUrlPrefix;
+      return this;
     }
 
     @Override
@@ -107,6 +117,9 @@ public class ClickHouseContainer extends BaseJdbcContainer<ClickHouseContainer> 
     args.add(config.containerName());
     args.add("--ulimit");
     args.add("nofile=262144:262144");
+
+    args.add("-e");
+    args.add("CLICKHOUSE_PASSWORD=" + dbConfig.getAdminPassword());
 
     args.add("-p");
     args.add(config.getPort() + ":" + config.getInternalPort());


### PR DESCRIPTION
Defaults the password to "test" for ClickHouse for both user and adminUser.

Uses the admin password "test" when creating the container which is now required.

Adds the connection.isValid(1) call to confirm
the connections (as ClickHouse jdbc kinda creates
a connection that is invalid - weird).