### PR TITLE
Add DataSource Builder to DbContainer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ For full programmatic test setup like:
 
   DatabaseBuilder ebeanBuilder = container.ebean().builder();
   Database ebeanDatabase = ebeanBuilder.build();
+
+  DataSourceBuilder dsBuilder = container.dataSourceBuilder();
+  DataSource dataSource = dsBuilder.build();
 ```
 
 Some containers like Redis, Localstack, LocalDynamoDB, ElasticSearch, ClickHouse do not have a concept

--- a/src/main/java/io/ebean/test/containers/DbContainer.java
+++ b/src/main/java/io/ebean/test/containers/DbContainer.java
@@ -1,5 +1,6 @@
 package io.ebean.test.containers;
 
+import io.ebean.datasource.DataSourceBuilder;
 import io.ebean.test.containers.process.ProcessHandler;
 
 import java.io.File;
@@ -113,6 +114,13 @@ abstract class DbContainer<C extends DbContainer<C>> extends BaseContainer<C> {
    */
   public EbeanSDK ebean() {
     return new EbeanAdapter(dbConfig);
+  }
+
+  /**
+   * Return a DataSource builder for the underlying database (url, username, password).
+   */
+  public DataSourceBuilder dataSourceBuilder() {
+    return ebean().dataSourceBuilder();
   }
 
   /**

--- a/src/test/java/io/ebean/test/containers/PostgresContainerTest.java
+++ b/src/test/java/io/ebean/test/containers/PostgresContainerTest.java
@@ -172,7 +172,7 @@ class PostgresContainerTest {
       .setParameter(2)
       .execute();
 
-    DataSourcePool dataSource = container.ebean().dataSourceBuilder().build();
+    DataSourcePool dataSource = container.dataSourceBuilder().build();
     try (Connection connection = dataSource.getConnection()) {
       exeSql(connection, "insert into foo_main (mcol) values (1)");
     }


### PR DESCRIPTION
In this way, if an application needs a container and ONLY a DataSource (and NOT ebean) then it can get one based off the containers url, username, password etc.